### PR TITLE
Fix for interrupt IDs above current max number and silent failing

### DIFF
--- a/include/bmboot/payload_runtime.hpp
+++ b/include/bmboot/payload_runtime.hpp
@@ -136,7 +136,8 @@ void stopPeriodicInterrupt();
 //! @param interruptId Platform-specific interrupt ID
 //! @param priority Interrupt priority. A high-priority interrupt may preempt a low priority one.
 //! @param handler Callback function
-void setupInterruptHandling(int interrupt_id, PayloadInterruptPriority priority, InterruptHandler handler);
+//! @return True if setup was successful, false otherwise
+bool setupInterruptHandling(int interrupt_id, PayloadInterruptPriority priority, InterruptHandler handler);
 
 //! Enable the reception of a peripheral interrupt.
 //!

--- a/src/bmboot_internal.hpp
+++ b/src/bmboot_internal.hpp
@@ -18,7 +18,7 @@ using Cookie = uint32_t;
 constexpr inline Cookie MONITOR_CODE_COOKIE = 0x7150ABCD;
 
 constexpr inline int GIC_MIN_USER_INTERRUPT_ID = 0;
-constexpr inline int GIC_MAX_USER_INTERRUPT_ID = 128;     // inclusive
+constexpr inline int GIC_MAX_USER_INTERRUPT_ID = 187;     // inclusive
 
 enum
 {

--- a/src/executor/payload/payload_runtime.cpp
+++ b/src/executor/payload/payload_runtime.cpp
@@ -36,17 +36,18 @@ AbiVersion bmboot::getMonitorAbiVersion()
                        .minor = major_minor & 0xff};
 }
 
-void bmboot::setupInterruptHandling(int interruptId, PayloadInterruptPriority priority, InterruptHandler handler)
+bool bmboot::setupInterruptHandling(int interruptId, PayloadInterruptPriority priority, InterruptHandler handler)
 {
     if (interruptId < GIC_MIN_USER_INTERRUPT_ID || interruptId > GIC_MAX_USER_INTERRUPT_ID)
     {
-        // TODO: signal error
-        return;
+        return false;
     }
 
     user_interrupt_handlers[interruptId - GIC_MIN_USER_INTERRUPT_ID] = std::move(handler);
 
     smc(SMC_ZYNQMP_GIC_IRQ_CONFIGURE, interruptId, (int) priority);
+
+    return true;
 }
 
 void bmboot::setupPeriodicInterrupt(std::chrono::microseconds period_us, InterruptHandler handler)


### PR DESCRIPTION
This PR resolves the issue #2 with the hard-coded maximal value of the GIC interrupt and silently failing if the provided value was out of specified bounds. The solution includes a change of return type of `setupInterruptHandling` to bool and a change of value of `GIC_MAX_USER_INTERRUPT_ID` to 187, the maximal value allowed on Zynq Ultrascale+ .

Tested on a Zynq Ultrascale+ (XCZU17EG-1FFVC1760), and this resolves the observed issue.