### PR TITLE
Fix to interleaving interrupts with floating-point operations

### DIFF
--- a/src/platform/zynqmp/executor/asm_vectors.S
+++ b/src/platform/zynqmp/executor/asm_vectors.S
@@ -52,14 +52,21 @@
 .globl FPUStatus
 
 /*
- * FPUContextSize is the size of the array where floating point registers are
+ * FPUContextSize is the size of the array (528) where floating point registers are
  * stored when required. The default size corresponds to the case when there is no
  * nested interrupt. If there are nested interrupts in application which are using
  * floating point operation, the size of FPUContextSize need to be increased as per
  * requirement
  */
 
-.set FPUContextSize, 528
+// The Zynq Ultrascale+ has 16 PL-PS interrupt IDs available, technically allowing
+// for that much of interleaving, however it is currently not supported in BMboot:
+// the payloads can define 8 priority levels and that is the maximum number of interleaving
+// that can be expected in the user code. To fully accomodate that possibility
+// and to avoid any issues, the context size below is extended by the same factor as the number
+// of priority levels, from 528 to 4224. The solution was tested on an Ultrascale+.
+
+.set FPUContextSize, 4224
 
 .macro saveregister
 	stp	X0,X1, [sp,#-0x10]!


### PR DESCRIPTION
This PR resolves the observed issue with interleaving interrupts using floating-point registers and with different priority levels, as reported in #5. 

The size of the array holding the floating point registers was extended by a factor of 16, as many as available PL-PS interrupts on an Ultrascale+ platform, following information from table 13-1 from the [Ultrascale+ technical manual](https://docs.amd.com/v/u/en-US/ug1085-zynq-ultrascale-trm).

I intended to add a payload allowing future users to run a test on their hardware to make sure it is resolved. However, I didn't find a way to do so without making assumptions about the FPGA IP cores existing on the given device. Therefore, unless @mcejp has an idea how to achieve that, I propose to merge it as-is. I have tested it on an Ultrascale+ of the CERN's FGC4 project, where we have over 8 available interrupt sources in the FPGA, and they all were successfully interleaving in my manual tests. I will add this to the FGC4 code repository.